### PR TITLE
Fixed "null" separator/ending issue.

### DIFF
--- a/stores/native.js
+++ b/stores/native.js
@@ -1,15 +1,7 @@
 function nativeStore(options) {
-  if(!options) {
-    options = {};
-  }
-  this.separator = options.separator || null;
-  this.lineEnding = options.lineEnd || null;
-  if (this.separator === null) {
-      this.separator = "null";
-  }
-  if (this.lineEnding === null) {
-      this.lineEnding = "null";
-  }
+  options = options || {};
+  this.separator = options.separator || "\t";
+  this.lineEnding = options.lineEnd || "\n";
 }
 
 nativeStore.prototype.init = function() {
@@ -17,7 +9,7 @@ nativeStore.prototype.init = function() {
 };
 
 nativeStore.prototype.stringify = function(data, callback) {
-  var processed = 'meta: {"separator": "'+this.separator+'", "lineEnding": "'+this.lineEnding+'"}\n';
+  var processed = "meta: "+ JSON.stringify({ separator: this.separator, lineEnding: this.lineEnding }) +"\n";
   for (var i in data) {
     processed += i + this.separator + JSON.stringify(data[i]) + this.lineEnding;
   }


### PR DESCRIPTION
When creating a database from a scratch, the separator and lineEnding were "null" (a string).
The original idea has probably been to use "\t" and "\n", so I made it so.

However, after that the writing routine wrote literal tab and linefeed to the file, so I escaped them with JSON.stringify() before writing.
